### PR TITLE
Fix for error: file exists in multiple modules

### DIFF
--- a/sdk/cosmosdb/build.zig
+++ b/sdk/cosmosdb/build.zig
@@ -5,6 +5,11 @@ pub fn build(b: *std.Build) void {
 
     const optimize = b.standardOptimizeOption(.{});
 
+    const azcore = b.dependency("azcore", .{
+        .target = target,
+        .optimize = optimize,
+    }).module("azcore");
+
     const lib = b.addStaticLibrary(.{
         .name = "azcosmosdb",
         .root_source_file = .{ .path = "src/root.zig" },
@@ -14,18 +19,14 @@ pub fn build(b: *std.Build) void {
 
     _ = b.addModule("azcosmos", .{
         .root_source_file = .{ .path = "src/root.zig" },
-        // .imports = &.{
-        //     .{
-        //         .name = "azcore",
-        //         .module = b.dependency("azcore", .{}).module("azcore"),
-        //     },
-        // },
+            .imports = &.{
+                .{
+                    .name = "azcore",
+                    .module = azcore,
+                },
+            },
     });
-
-    lib.root_module.addImport("azcore", b.dependency("azcore", .{
-        .target = target,
-        .optimize = optimize,
-    }).module("azcore"));
+    lib.root_module.addImport("azcore", azcore);
 
     b.installArtifact(lib);
 


### PR DESCRIPTION
Hi, 

I believe the error message: 
```
error: file exists in multiple modules
note: root of module azcore0
note: root of module azcore
```
was most likely caused by a mismatch between the Module.CreateOptions of 
```
.imports = &.{
  .{
    .name = "azcore",
    .module = b.dependency("azcore", .{}).module("azcore"),
  },
},
```
and
```
lib.root_module.addImport("azcore", b.dependency("azcore", .{
  .target = target,
  .optimize = optimize,
}).module("azcore"));
```